### PR TITLE
Address finalize method deprecation in Nutch

### DIFF
--- a/src/java/org/apache/nutch/plugin/Plugin.java
+++ b/src/java/org/apache/nutch/plugin/Plugin.java
@@ -38,7 +38,7 @@ import org.apache.hadoop.conf.Configuration;
  * 
  * @author joa23
  */
-public class Plugin {
+public class Plugin implements AutoCloseable {
   private PluginDescriptor fDescriptor;
   protected Configuration conf;
 
@@ -90,7 +90,7 @@ public class Plugin {
   }
 
   @Override
-  protected void finalize() throws Throwable {
+  public void close() throws PluginRuntimeException {
     shutDown();
   }
 }

--- a/src/java/org/apache/nutch/plugin/PluginRepository.java
+++ b/src/java/org/apache/nutch/plugin/PluginRepository.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * how the JVM creates URLs can be seen in the API documentation for the
  * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/URL.html#%3Cinit%3E(java.lang.String,java.lang.String,int,java.lang.String)">URL constructor</a>.</p>
  */
-public class PluginRepository implements URLStreamHandlerFactory {
+public class PluginRepository implements URLStreamHandlerFactory, AutoCloseable {
   private static final WeakHashMap<String, PluginRepository> CACHE = new WeakHashMap<>();
 
   private boolean auto;
@@ -103,6 +103,9 @@ public class PluginRepository implements URLStreamHandlerFactory {
     }
 
     registerURLStreamHandlerFactory();
+
+    // Ensure active plugins are shut down on JVM termination
+    PluginRepositoryShutdownHook.register(this);
 
     displayStatus();
   }
@@ -313,17 +316,15 @@ public class PluginRepository implements URLStreamHandlerFactory {
     }
   }
 
-  /**
-   * Attempts to shut down all activated plugins.
-   * @deprecated
-   * @see <a href="https://openjdk.java.net/jeps/421">JEP 421: Deprecate Finalization for Removal</a>
-   * @see java.lang.Object#finalize()
-   * @deprecated
-   */
+  private volatile boolean closed = false;
+
   @Override
-  @Deprecated
-  public void finalize() throws Throwable {
+  public synchronized void close() throws PluginRuntimeException {
+    if (this.closed) {
+      return;
+    }
     shutDownActivatedPlugins();
+    this.closed = true;
   }
 
   /**

--- a/src/java/org/apache/nutch/plugin/PluginRepositoryShutdownHook.java
+++ b/src/java/org/apache/nutch/plugin/PluginRepositoryShutdownHook.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.plugin;
+
+import java.lang.invoke.MethodHandles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Registers a JVM shutdown hook to close a {@link PluginRepository} and ensure
+ * all activated plugins are shut down.
+ */
+final class PluginRepositoryShutdownHook implements Runnable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final PluginRepository repository;
+
+  private PluginRepositoryShutdownHook(PluginRepository repository) {
+    this.repository = repository;
+  }
+
+  static void register(PluginRepository repository) {
+    Runtime.getRuntime().addShutdownHook(new Thread(new PluginRepositoryShutdownHook(repository),
+            "nutch-pluginrepository-shutdown"));
+  }
+
+  @Override
+  public void run() {
+    try {
+      repository.close();
+    } catch (Exception e) {
+      LOG.warn("Error while shutting down PluginRepository during JVM shutdown.", e);
+    }
+  }
+}
+

--- a/src/plugin/protocol-ftp/src/java/org/apache/nutch/protocol/ftp/Ftp.java
+++ b/src/plugin/protocol-ftp/src/java/org/apache/nutch/protocol/ftp/Ftp.java
@@ -48,7 +48,7 @@ import java.io.IOException;
  * {@code ftp.password}, {@code ftp.keep.connection} and {@code ftp.follow.talk}
  * . For details see "FTP properties" section in {@code nutch-default.xml}.
  */
-public class Ftp implements Protocol {
+public class Ftp implements Protocol, AutoCloseable {
 
   protected static final Logger LOG = LoggerFactory
       .getLogger(MethodHandles.lookup().lookupClass());
@@ -188,15 +188,8 @@ public class Ftp implements Protocol {
   }
 
   @Override
-  protected void finalize() {
-    try {
-      if (this.client != null && this.client.isConnected()) {
-        this.client.logout();
-        this.client.disconnect();
-      }
-    } catch (IOException e) {
-      // do nothing
-    }
+  public void close() {
+    FtpUtils.closeQuietly(this.client);
   }
 
   /** 
@@ -242,33 +235,31 @@ public class Ftp implements Protocol {
       }
     }
 
-    Ftp ftp = new Ftp();
+    try (Ftp ftp = new Ftp()) {
+      ftp.setFollowTalk(followTalk);
+      ftp.setKeepConnection(keepConnection);
 
-    ftp.setFollowTalk(followTalk);
-    ftp.setKeepConnection(keepConnection);
+      if (timeout != Integer.MIN_VALUE) // set timeout
+        ftp.setTimeout(timeout);
 
-    if (timeout != Integer.MIN_VALUE) // set timeout
-      ftp.setTimeout(timeout);
+      if (maxContentLength != Integer.MIN_VALUE) // set maxContentLength
+        ftp.setMaxContentLength(maxContentLength);
 
-    if (maxContentLength != Integer.MIN_VALUE) // set maxContentLength
-      ftp.setMaxContentLength(maxContentLength);
+      // set log level
+      // LOG.setLevel(Level.parse((new String(logLevel)).toUpperCase()));
 
-    // set log level
-    // LOG.setLevel(Level.parse((new String(logLevel)).toUpperCase()));
+      Content content = ftp.getProtocolOutput(new Text(urlString),
+          new CrawlDatum()).getContent();
 
-    Content content = ftp.getProtocolOutput(new Text(urlString),
-        new CrawlDatum()).getContent();
-
-    System.err.println("Content-Type: " + content.getContentType());
-    System.err.println("Content-Length: "
-        + content.getMetadata().get(Response.CONTENT_LENGTH));
-    System.err.println("Last-Modified: "
-        + content.getMetadata().get(Response.LAST_MODIFIED));
-    if (dumpContent) {
-      System.out.print(new String(content.getContent()));
+      System.err.println("Content-Type: " + content.getContentType());
+      System.err.println("Content-Length: "
+          + content.getMetadata().get(Response.CONTENT_LENGTH));
+      System.err.println("Last-Modified: "
+          + content.getMetadata().get(Response.LAST_MODIFIED));
+      if (dumpContent) {
+        System.out.print(new String(content.getContent()));
+      }
     }
-
-    ftp = null;
   }
 
   /**

--- a/src/plugin/protocol-ftp/src/java/org/apache/nutch/protocol/ftp/FtpUtils.java
+++ b/src/plugin/protocol-ftp/src/java/org/apache/nutch/protocol/ftp/FtpUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nutch.protocol.ftp;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class FtpUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private FtpUtils() {}
+
+  static void closeQuietly(Client client) {
+    if (client == null) {
+      return;
+    }
+    try {
+      if (client.isConnected()) {
+        try {
+          client.logout();
+        } catch (IOException e) {
+          LOG.debug("Error during FTP client logout.", e);
+        }
+        try {
+          client.disconnect();
+        } catch (IOException e) {
+          LOG.debug("Error during FTP client disconnect.", e);
+        }
+      }
+    } catch (Exception e) {
+      LOG.debug("Error while closing FTP client.", e);
+    }
+  }
+}
+


### PR DESCRIPTION
Thanks for your contribution to [Apache Nutch](https://nutch.apache.org/)! Your help is appreciated!

Before opening the pull request, please verify that
* there is an open issue on the [Nutch issue tracker](https://issues.apache.org/jira/projects/NUTCH) which describes the problem or the improvement. We cannot accept pull requests without an issue because the change wouldn't be listed in the release notes.
* the issue ID (`NUTCH-XXXX`)
  - is referenced in the title of the pull request
  - and placed in front of your commit messages surrounded by square brackets (`[NUTCH-XXXX] Issue or pull request title`)
* commits are squashed into a single one (or few commits for larger changes)
* Java source code follows [Nutch Eclipse Code Formatting rules](https://github.com/apache/nutch/blob/master/eclipse-codeformat.xml)
* Nutch is successfully built and unit tests pass by running `ant clean runtime test`
* there should be no conflicts when merging the pull request branch into the *recent* master branch. If there are conflicts, please try to rebase the pull request branch on top of a freshly pulled master branch.
* if new dependencies are added,
  - are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
  - are `LICENSE-binary` and `NOTICE-binary` updated accordingly?

We will be able to faster integrate your pull request if these conditions are met. If you have any questions how to fix your problem or about using Nutch in general, please sign up for the [Nutch mailing list](https://nutch.apache.org/mailing_lists.html). Thanks!

---

This pull request addresses the deprecation of `Object.finalize()` by replacing its usage with modern, deterministic resource management patterns across `Plugin`, `PluginRepository`, and `Ftp` classes.

**Changes include:**

*   **`org.apache.nutch.plugin.Plugin`**: Replaced `finalize()` with `AutoCloseable.close()`, delegating to the existing `shutDown()` method for explicit resource management.
*   **`org.apache.nutch.plugin.PluginRepository`**: Replaced `finalize()` with `AutoCloseable.close()` to shut down activated plugins. A JVM shutdown hook (`PluginRepositoryShutdownHook`) was added to ensure `close()` is called reliably on JVM termination, maintaining a "last resort" cleanup mechanism without relying on finalization.
*   **`org.apache.nutch.protocol.ftp.Ftp`**: Replaced `finalize()` with `AutoCloseable.close()` for deterministic cleanup (logout and disconnect) of FTP client resources. The `main()` method was updated to use try-with-resources for safe and automatic resource handling. A new `FtpUtils.closeQuietly` helper was introduced for robust client cleanup.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4a6cd5d-75e2-4fe3-87f9-3cf5a6aecff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d4a6cd5d-75e2-4fe3-87f9-3cf5a6aecff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

