### PR TITLE
Address javac finalize deprecation warnings

### DIFF
--- a/src/java/org/apache/nutch/plugin/Plugin.java
+++ b/src/java/org/apache/nutch/plugin/Plugin.java
@@ -38,7 +38,7 @@ import org.apache.hadoop.conf.Configuration;
  * 
  * @author joa23
  */
-public class Plugin {
+public class Plugin implements AutoCloseable {
   private PluginDescriptor fDescriptor;
   protected Configuration conf;
 
@@ -90,7 +90,7 @@ public class Plugin {
   }
 
   @Override
-  protected void finalize() throws Throwable {
+  public void close() throws PluginRuntimeException {
     shutDown();
   }
 }


### PR DESCRIPTION
Thanks for your contribution to [Apache Nutch](https://nutch.apache.org/)! Your help is appreciated!

Before opening the pull request, please verify that
* there is an open issue on the [Nutch issue tracker](https://issues.apache.org/jira/projects/NUTCH) which describes the problem or the improvement. We cannot accept pull requests without an issue because the change wouldn't be listed in the release notes.
* the issue ID (`NUTCH-XXXX`)
  - is referenced in the title of the pull request
  - and placed in front of your commit messages surrounded by square brackets (`[NUTCH-XXXX] Issue or pull request title`)
* commits are squashed into a single one (or few commits for larger changes)
* Java source code follows [Nutch Eclipse Code Formatting rules](https://github.com/apache/nutch/blob/master/eclipse-codeformat.xml)
* Nutch is successfully built and unit tests pass by running `ant clean runtime test`
* there should be no conflicts when merging the pull request branch into the *recent* master branch. If there are conflicts, please try to rebase the pull request branch on top of a freshly pulled master branch.
* if new dependencies are added,
  - are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
  - are `LICENSE-binary` and `NOTICE-binary` updated accordingly?

We will be able to faster integrate your pull request if these conditions are met. If you have any questions how to fix your problem or about using Nutch in general, please sign up for the [Nutch mailing list](https://nutch.apache.org/mailing_lists.html). Thanks!

[NUTCH-XXXX] Replace deprecated `finalize()` with `AutoCloseable.close()` in `Plugin.java`

This change addresses `javac` deprecation warnings by replacing the `Object.finalize()` method in `org.apache.nutch.plugin.Plugin` with an implementation of `AutoCloseable.close()`. This provides a more explicit and reliable mechanism for resource cleanup.

---
<a href="https://cursor.com/background-agent?bcId=bc-b613d09f-dd96-4038-b2b4-f1cad05c4c68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b613d09f-dd96-4038-b2b4-f1cad05c4c68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

